### PR TITLE
implement cache for files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
         
       - name: Build
         run: |
-          cargo build
-          cargo build --release
-          cargo test
-          cargo test --release
+          cargo build teleprobe
+          cargo build teleprobe --release
+          cargo test teleprobe
+          cargo test teleprobe --release
     

--- a/teleprobe/Cargo.lock
+++ b/teleprobe/Cargo.lock
@@ -332,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+
+[[package]]
 name = "defmt-decoder"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +461,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "flate2"
@@ -599,6 +611,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1157,6 +1180,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "orion"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11468cc6afd61a126fe3f91cc4cc8a0dbe7917d0a4b5e8357ba91cc47444462"
+dependencies = [
+ "ct-codecs",
+ "fiat-crypto",
+ "getrandom",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "svg"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1733,7 @@ dependencies = [
  "object 0.30.3",
  "once_cell",
  "openssl",
+ "orion",
  "parking_lot",
  "pin-project-lite",
  "pretty_env_logger",
@@ -2312,3 +2356,9 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/teleprobe/Cargo.lock
+++ b/teleprobe/Cargo.lock
@@ -728,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hidapi"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,7 +1194,6 @@ dependencies = [
  "ct-codecs",
  "fiat-crypto",
  "getrandom",
- "serde",
  "subtle",
  "zeroize",
 ]
@@ -1728,6 +1733,7 @@ dependencies = [
  "defmt-decoder",
  "futures",
  "git-version",
+ "hex",
  "jsonwebtoken",
  "log",
  "object 0.30.3",

--- a/teleprobe/Cargo.toml
+++ b/teleprobe/Cargo.toml
@@ -34,7 +34,8 @@ pin-project-lite = "0.2.9"
 backtrace = "0.3.67"
 futures = "0.3.28"
 walkdir = "2.3.3"
-orion = { version = "0.17.5", features = ["serde"] }
+orion = "0.17.5"
+hex = "0.4.3"
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.52", optional = true }

--- a/teleprobe/Cargo.toml
+++ b/teleprobe/Cargo.toml
@@ -34,6 +34,7 @@ pin-project-lite = "0.2.9"
 backtrace = "0.3.67"
 futures = "0.3.28"
 walkdir = "2.3.3"
+orion = { version = "0.17.5", features = ["serde"] }
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.52", optional = true }

--- a/teleprobe/src/client.rs
+++ b/teleprobe/src/client.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context};
 use futures::{stream, StreamExt};
 use log::{error, info, warn};
 use object::{Object, ObjectSection};
+use orion::hash::digest;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
@@ -42,6 +44,12 @@ pub struct RunCommand {
     #[clap(long)]
     target: Option<String>,
 
+    /// Cache file to avoid re-running binaries.
+    /// If not specified, all binaries will be run.
+    /// If specified, only the binaries that have changed will be run.
+    #[clap(long)]
+    cache: Option<String>,
+
     /// ELF files to flash+run
     files: Vec<String>,
 
@@ -63,6 +71,12 @@ pub async fn main(cmd: Command) -> anyhow::Result<()> {
         Subcommand::ListTargets => list_targets(&cmd.credentials).await,
         Subcommand::Run(scmd) => run(&cmd.credentials, scmd).await,
     }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct Cache {
+    /// A map of file checksums that have passed the test.
+    files: HashMap<String, ()>,
 }
 
 #[derive(Clone, Default, Debug)]
@@ -104,6 +118,7 @@ struct Job {
     path: PathBuf,
     target: String,
     elf: Vec<u8>,
+    hash: String,
     timeout: Option<u64>,
 }
 
@@ -113,7 +128,7 @@ struct RunArgs {
     timeout: Option<u64>,
 }
 
-async fn run_job(client: &Client, creds: &Credentials, job: Job, show_output: bool) -> bool {
+async fn run_job(client: &Client, creds: &Credentials, job: Job, show_output: bool) -> (bool, String) {
     let res = client
         .post(format!("{}/targets/{}/run", creds.host, job.target))
         .query(&RunArgs { timeout: job.timeout })
@@ -146,13 +161,30 @@ async fn run_job(client: &Client, creds: &Credentials, job: Job, show_output: bo
             if show_output {
                 info!("{}", logs);
             }
-            true
+            (true, job.hash.clone())
         }
         Err(e) => {
             error!("=== {} {}: FAILED: {}", job.target, job.path.display(), e);
             error!("{}", logs);
-            false
+            (false, String::new())
         }
+    }
+}
+
+fn load_cache(cache: Option<String>) -> Cache {
+    let cache = match cache {
+        Some(cache) => cache,
+        _ => return Cache::default(),
+    };
+
+    let cache_file = match File::open(cache) {
+        Ok(cache_file) => cache_file,
+        _ => return Cache::default(),
+    };
+
+    match serde_json::from_reader(&cache_file) {
+        Ok(cache) => cache,
+        _ => return Cache::default(),
     }
 }
 
@@ -174,11 +206,14 @@ async fn run(creds: &Credentials, cmd: RunCommand) -> anyhow::Result<()> {
         cmd.files.iter().map(|f| f.into()).collect()
     };
 
+    let before_cache = load_cache(cmd.cache.clone());
+    let mut after_cache = Cache::default();
     let job_count = files.len();
     let mut jobs_by_target: HashMap<String, Vec<Job>> = HashMap::new();
 
     for path in files {
         let elf: Vec<u8> = std::fs::read(&path)?;
+        let hash = serde_json::to_string(&digest(elf.as_slice()).unwrap()).unwrap();
         let meta = ElfMetadata::from_elf(&elf)?;
 
         let target = cmd
@@ -187,10 +222,18 @@ async fn run(creds: &Credentials, cmd: RunCommand) -> anyhow::Result<()> {
             .or(meta.target)
             .context("You have to either set --target, or embed it in the ELF using the `teleprobe-meta` crate.")?;
 
+        if before_cache.files.contains_key(&hash) {
+            info!("=== {} {}: SKIPPED", target, path.display());
+            after_cache.files.insert(hash, ());
+
+            continue;
+        }
+
         jobs_by_target.entry(target.clone()).or_default().push(Job {
             path,
             target,
             elf,
+            hash,
             timeout: meta.timeout,
         });
     }
@@ -211,12 +254,30 @@ async fn run(creds: &Credentials, cmd: RunCommand) -> anyhow::Result<()> {
 
     let mut succeeded = 0;
     let mut failed = 0;
-    for r in results {
+    for (r, hash) in results {
         match r {
-            true => succeeded += 1,
+            true => {
+                after_cache.files.insert(hash, ());
+
+                succeeded += 1
+            }
             false => failed += 1,
         }
     }
+
+    cmd.cache.map(|cache| {
+        let cache_file = match File::create(&cache) {
+            Ok(cache_file) => cache_file,
+            _ => return,
+        };
+
+        match serde_json::to_writer(cache_file, &after_cache) {
+            Ok(_) => println!("saved cache to {}", &cache),
+            Err(_) => println!("failed to saved cache to {}", &cache),
+        };
+
+        // I assume the file is closed when it's dropped here
+    });
 
     if failed != 0 {
         log::error!("{} succeeded, {} failed :(", succeeded, failed);

--- a/teleprobe/src/client.rs
+++ b/teleprobe/src/client.rs
@@ -213,7 +213,7 @@ async fn run(creds: &Credentials, cmd: RunCommand) -> anyhow::Result<()> {
 
     for path in files {
         let elf: Vec<u8> = std::fs::read(&path)?;
-        let hash = serde_json::to_string(&digest(elf.as_slice()).unwrap()).unwrap();
+        let hash = hex::encode(&digest(elf.as_slice()).unwrap());
         let meta = ElfMetadata::from_elf(&elf)?;
 
         let target = cmd


### PR DESCRIPTION
I decided that storing the hash of the file is enough (there's no need to store the file location because hash collision doesn't need to be considered), and that hashes are purged immediately if the binary is not retried. In addition, the hash code is always run because it's relatively cheap and reduces branching, improving code coverage.

closes #8.