### PR TITLE
add power reset feature depending on an installation of uhubctl in PATH

### DIFF
--- a/teleprobe/Cargo.toml
+++ b/teleprobe/Cargo.toml
@@ -42,3 +42,6 @@ openssl = { version = "0.10.52", optional = true }
 
 [build-dependencies]
 git-version = "0.3.5"
+
+[features]
+power_reset = []

--- a/teleprobe/src/api.rs
+++ b/teleprobe/src/api.rs
@@ -10,6 +10,8 @@ pub struct Target {
     pub connect_under_reset: bool,
     pub speed: Option<u32>,
     pub up: bool,
+    #[cfg(feature = "power_reset")]
+    pub power_reset: bool
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/teleprobe/src/config.rs
+++ b/teleprobe/src/config.rs
@@ -65,6 +65,9 @@ pub struct Target {
     pub connect_under_reset: bool,
     #[serde(default)]
     pub speed: Option<u32>,
+    #[cfg(feature = "power_reset")]
+    #[serde(default)]
+    pub power_reset: bool
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/teleprobe/src/server.rs
+++ b/teleprobe/src/server.rs
@@ -191,6 +191,8 @@ async fn handle_run(name: String, args: RunArgs, elf: Bytes, cx: Arc<Mutex<Conte
         connect_under_reset: target.connect_under_reset,
         probe: Some(target.probe.clone()),
         speed: target.speed,
+        #[cfg(feature = "power_reset")]
+        power_reset: target.power_reset,
     };
 
     let timeout = {
@@ -218,6 +220,8 @@ fn targets(cx: Arc<Mutex<Context>>) -> api::TargetList {
             connect_under_reset: target.connect_under_reset,
             speed: target.speed,
             up: is_up,
+            #[cfg(feature = "power_reset")]
+            power_reset: target.power_reset,
         });
     }
 


### PR DESCRIPTION
I originally wanted to implement the power reset within rust without using `uhubctl` directly.
Unfortunately, that is not as trivial as thought and would take longer, but is still a goal.

This version calls `uhubctl` and resets the power by searching for the probe with its serial.

Power reset needs to be enabled as feature `power_reset` and the probe target/probe needs the option `power_reset` set to `true`.

This should be a viable solution, especially for testing if this works reliably. On macOS (my machine) it happens from time to time that the device is not recognized again after 100+ resets, but that can be just macOS and resetting a device in a loop.