### PR TITLE
Implement "exported" variables allowing to pull data from firmware.

### DIFF
--- a/teleprobe-meta/teleprobe.x
+++ b/teleprobe-meta/teleprobe.x
@@ -8,4 +8,8 @@ SECTIONS
   {
     KEEP(*(.teleprobe.timeout));
   }
+  .teleprobe.export (INFO) :
+  {
+    KEEP(*(.teleprobe.export));
+  }
 }

--- a/teleprobe/src/run.rs
+++ b/teleprobe/src/run.rs
@@ -56,6 +56,8 @@ struct Runner {
     defmt_stream: Box<dyn StreamDecoder>,
 
     di: DebugInfo,
+
+    exports: BTreeMap<String, u32>,
 }
 
 unsafe fn fuck_it<'a, 'b, T>(wtf: &'a T) -> &'b T {
@@ -116,6 +118,36 @@ impl Runner {
 
         let vector_table = vector_table.ok_or_else(|| anyhow!("`.vector_table` section is missing"))?;
         log::debug!("vector table: {:x?}", vector_table);
+
+        // Build a map of exported variables, based on addresses found in the
+        // '.teleprobe.export' section.
+        let mut export_map = BTreeMap::new();
+
+        if let Some(section) = elf.section_by_name(".teleprobe.export") {
+            let ptrs = section
+                .data()?
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect::<Vec<_>>();
+
+            if ptrs.len() > 0 {
+                info!("Found {} exported variables: {:#0x?}", ptrs.len(), ptrs);
+
+                // TODO: Is there a better way?
+                for symbol in elf.symbols() {
+                    if ptrs.contains(&(symbol.address() as u32)) {
+                        let addr = symbol.address() as u32;
+                        let name = String::from(symbol.name().unwrap());
+                        // Filter out private symbols, otherwise we get some false-positives
+                        if name.starts_with("__") {
+                            continue;
+                        }
+                        export_map.insert(String::from(symbol.name().unwrap()), addr);
+                        info!("Found match for addr {:?} -> {:?}", &addr, &name);
+                    }
+                }
+            }
+        }
 
         // reset ALL cores other than the main one.
         // This is needed for rp2040 core1.
@@ -244,6 +276,7 @@ impl Runner {
             defmt,
             defmt_stream,
             di,
+            exports: export_map,
         })
     }
 
@@ -342,6 +375,30 @@ impl Runner {
             bail!("Firmware crashed");
         }
 
+        // Look up exported symbols
+        for (symbol, addr) in &self.exports {
+            let mut buf = [0; 64];
+            /*
+            // XXX: Ideally we should use demangling information to
+            // either handle references ie bytestrings are stored as
+            // pointers to data. But for now, we only support hardcoded
+            // byte arrays of length 64.
+            let ptr = core.read_word_32(*addr as u64).unwrap();
+            let _ = core.read(ptr as u64, &mut buf).unwrap();
+            */
+            // TODO: Error handling?
+            let _ = core.read(*addr as u64, &mut buf).unwrap();
+            match String::from_utf8(buf.to_vec()) {
+                Ok(s) => {
+                    info!("Found: {} -> {}", symbol, s);
+                }
+                Err(_) => {
+                    warn!("Data for {} not found!", symbol);
+                }
+            }
+        }
+        // TODO: Export our wanted symbols?
+
         Ok(())
     }
 
@@ -439,7 +496,7 @@ impl Runner {
     fn dump_state(&mut self, core: &mut Core, force: bool) -> anyhow::Result<bool> {
         core.halt(TIMEOUT)?;
 
-        // determine if the target is handling an interupt
+        // determine if the target is handling an interrupt
         let xpsr: u32 = core.read_core_reg(XPSR)?;
         let exception_number = xpsr & 0xff;
         match exception_number {


### PR DESCRIPTION
This implements basic groundwork for pulling data from firmware.

Demo:
```
 INFO  teleprobe::run > Found 2 exported variables: [
    0x2000c9a0,
    0x2000c9e0,
]
 INFO  teleprobe::run > Found match for addr 536922592 -> "_ZN5timer15_TELEPROBE_VAR217hd7ca27c6503da4d3E"
 INFO  teleprobe::run > Found match for addr 536922528 -> "_TELEPROBE_VAR1"
 INFO  teleprobe::run > run_from_ram: true
 INFO  teleprobe::run > flashing program...
 INFO  teleprobe::run > flashing done!
 INFO  device         > 0.101898 Test OK
 INFO  teleprobe::run > Found: _TELEPROBE_VAR1 -> yesyesno
 INFO  teleprobe::run > Found: _ZN5timer15_TELEPROBE_VAR217hd7ca27c6503da4d3E -> nonoyes!

```
Firmware-side changes (some "sugaring" would be eventually nice, but it works):
```rust
#[repr(C)]
union TPVar {
    f1: [u8; 64],
    f2: u32,
}

#[no_mangle]
static mut _TELEPROBE_VAR1: TPVar = TPVar { f1: [0; 64] };

// This works as well...
static mut _TELEPROBE_VAR2: TPVar = TPVar { f1: [0; 64] };

#[repr(C)]
pub struct TPPtr(*const u32);
unsafe impl Sync for TPPtr {}

#[link_section = ".teleprobe.export"]
#[used]
#[no_mangle]
static _TELEPROBE_EXPORTS: [TPPtr; 2] = [
    TPPtr(unsafe { &_TELEPROBE_VAR1.f2 as *const u32 }),
    TPPtr(unsafe { &_TELEPROBE_VAR2.f2 as *const u32 }),
];

fn main(...) {
    // Update our variables with custom data:
    unsafe {
        let data = b"yesyesno";
        _TELEPROBE_VAR1.f1[..data.len()].copy_from_slice(data);
        let data = b"nonoyes!";
        _TELEPROBE_VAR2.f1[..data.len()].copy_from_slice(data);

        info!(
            "new: _TELEPROBE_VAR1: ptr = {:?}, val = {:?} ",
            &mut _TELEPROBE_VAR1.f1 as *mut _, _TELEPROBE_VAR1.f1
        );
    }
}
```