### PR TITLE
Allow local runs to select protocol for debugger

### DIFF
--- a/teleprobe/src/probe/mod.rs
+++ b/teleprobe/src/probe/mod.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use probe_rs::probe::list::Lister;
-use probe_rs::probe::{DebugProbeSelector, Probe};
+use probe_rs::probe::{DebugProbeSelector, Probe, WireProtocol};
 use probe_rs::{MemoryInterface, Permissions, Session};
 
 const SETTLE_REPROBE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
@@ -35,6 +35,10 @@ pub struct Opts {
 
     #[clap(long, default_value = "2000")]
     pub max_settle_time_millis: u64,
+
+    /// Protocol to use for communication to probe.
+    #[clap(long)]
+    pub protocol: Option<WireProtocol>,
 }
 
 pub fn list() -> Result<()> {
@@ -130,6 +134,10 @@ pub fn connect(opts: &Opts) -> Result<Session> {
 
     if let Some(speed) = opts.speed {
         probe.set_speed(speed)?;
+    }
+
+    if let Some(protocol) = opts.protocol {
+        probe.select_protocol(protocol)?;
     }
 
     let perms = Permissions::new().allow_erase_all();

--- a/teleprobe/src/run.rs
+++ b/teleprobe/src/run.rs
@@ -70,7 +70,7 @@ impl Runner {
 
         let di = DebugInfo::from_raw(elf_bytes)?;
 
-        let table = Box::new(defmt_decoder::Table::parse(elf_bytes)?.unwrap());
+        let table = Box::new(defmt_decoder::Table::parse(elf_bytes)?.expect("no defmt table"));
         let locs = table.get_locations(elf_bytes)?;
         if !table.is_empty() && locs.is_empty() {
             log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");

--- a/teleprobe/src/server.rs
+++ b/teleprobe/src/server.rs
@@ -184,6 +184,7 @@ async fn handle_run(name: String, args: RunArgs, elf: Bytes, cx: Arc<Mutex<Conte
         power_reset: target.power_reset,
         cycle_delay_seconds: target.cycle_delay_seconds,
         max_settle_time_millis: target.max_settle_time_millis,
+        protocol: None,
     };
 
     let timeout = {


### PR DESCRIPTION
This is required for the MSPM0 Launchpad boards because these advertise JTAG. However the chips only proide SWD.

For the future a way to configure this for a server run is also needed... This is so that I can run teleprobe locally.